### PR TITLE
feat(frontend): Add error toast for unauthorized tickect booking

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -24,6 +24,7 @@
     "prop-types": "^15.8.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-hot-toast": "^2.4.1",
     "react-router-dom": "^6.11.2",
     "sass": "^1.62.1",
     "zustand": "^4.3.8"

--- a/frontend/src/components/BusTicket/index.tsx
+++ b/frontend/src/components/BusTicket/index.tsx
@@ -2,7 +2,6 @@ import {Typography, Box, Button} from '@mui/material';
 import ConfirmationNumberIcon from '@mui/icons-material/ConfirmationNumber';
 import ShareLocationIcon from '@mui/icons-material/ShareLocation';
 import type {BusTicketData} from './ticketData';
-// eslint-disable-next-line node/no-extraneous-import
 import toast, {Toaster} from 'react-hot-toast';
 import {useAuthStore} from '../../store/authStore';
 import React from 'react';

--- a/frontend/src/components/BusTicket/index.tsx
+++ b/frontend/src/components/BusTicket/index.tsx
@@ -2,6 +2,10 @@ import {Typography, Box, Button} from '@mui/material';
 import ConfirmationNumberIcon from '@mui/icons-material/ConfirmationNumber';
 import ShareLocationIcon from '@mui/icons-material/ShareLocation';
 import type {BusTicketData} from './ticketData';
+// eslint-disable-next-line node/no-extraneous-import
+import toast, {Toaster} from 'react-hot-toast';
+import {useAuthStore} from '../../store/authStore';
+import React from 'react';
 
 export default function BusTicket({
   checkpoints,
@@ -9,6 +13,23 @@ export default function BusTicket({
   price,
   seatsLeft,
 }: BusTicketData) {
+  const [isToasterActive, setIsToasterActive] = React.useState(false);
+
+  const notify = () => {
+    if (!isToasterActive) {
+      setIsToasterActive(true);
+
+      toast.error('You need to login first', {
+        position: 'top-center',
+        duration: 3000,
+      });
+    }
+
+    setTimeout(() => {
+      setIsToasterActive(false);
+    }, 3000);
+  };
+  const {isAuth} = useAuthStore();
   return (
     <Box
       sx={{
@@ -135,6 +156,7 @@ export default function BusTicket({
             {seatsLeft} Seats Left
           </Typography>
           <Button
+            onClick={notify}
             variant="contained"
             startIcon={<ConfirmationNumberIcon />}
             sx={{
@@ -148,6 +170,8 @@ export default function BusTicket({
           >
             Book Ticket
           </Button>
+
+          {!isAuth && <Toaster position="top-center" />}
         </Box>
       </Box>
     </Box>


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #11 .
2. This PR does the following: 
     This commit adds a new feature that displays an error toast when attempting to purchase tickets without being logged in. 
      The toast is now displayed only once, preventing multiple notifications from appearing.

The toast provides a clear indication to the user that they need to log in before buying tickets, improving the user experience and preventing confusion.

This feature enhances the application's usability and ensures a smoother ticket purchasing process for users.
The Toast will bounce for 3-4 seconds when the user will click on Book tickets without being logged in . 

I have added the package.json file because it contains the necessary dependencies for react-hot-toast.

## Proof that changes are correct

Error Toast appears when the user is attempting to purchase tickets without being logged in.(it will show like this)
![Screenshot (30)](https://github.com/bsoc-bitbyte/busify/assets/128512586/ceaa6fb7-cc0b-448e-8af9-a325c24fd27c)

![Screenshot (32)](https://github.com/bsoc-bitbyte/busify/assets/128512586/31e9a145-6a7c-4415-b051-97d5353d32db)



When the user attempt to buy ticket when he has logged in. (It will not show the toast)

![Screenshot (31)](https://github.com/bsoc-bitbyte/busify/assets/128512586/15285c27-3e59-47f4-84b2-205b6d71d5da)




