### PR TITLE
feat(frontend): Add UserProtected Route

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,8 +8,12 @@ import Navbar from './components/Navbar';
 import Footer from './components/Footer';
 import BusSchedule from './pages/BusSchedule';
 import BusDetails from './components/BusDetails';
+import Demopage from './pages/DemoPage/demopage';
+import UserProtectedRoute from './components/ProtectedRoutes';
+import {useAuthStore} from './store/authStore';
 
 function App() {
+  const {isAuth} = useAuthStore();
   return (
     <ThemeProvider theme={theme}>
       <ValidateAuth />
@@ -21,6 +25,14 @@ function App() {
           <Route path="/google" element={<GoogleAuthLogin />} />
           <Route path="/bus-schedule" element={<BusSchedule />} />
           <Route path="/bus-details" element={<BusDetails />} />
+          <Route
+            path="/demo-Page"
+            element={
+              <UserProtectedRoute isAuth={isAuth}>
+                <Demopage />
+              </UserProtectedRoute>
+            }
+          />
         </Routes>
         <Footer />
       </Box>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,10 +10,8 @@ import BusSchedule from './pages/BusSchedule';
 import BusDetails from './components/BusDetails';
 import Demopage from './pages/DemoPage/demopage';
 import UserProtectedRoute from './components/ProtectedRoutes';
-import {useAuthStore} from './store/authStore';
 
 function App() {
-  const {isAuth} = useAuthStore();
   return (
     <ThemeProvider theme={theme}>
       <ValidateAuth />
@@ -28,7 +26,7 @@ function App() {
           <Route
             path="/demo-Page"
             element={
-              <UserProtectedRoute isAuth={isAuth}>
+              <UserProtectedRoute>
                 <Demopage />
               </UserProtectedRoute>
             }

--- a/frontend/src/components/BusDetails/index.tsx
+++ b/frontend/src/components/BusDetails/index.tsx
@@ -16,6 +16,7 @@ import CloseIcon from '@mui/icons-material/Close';
 import AddIcon from '@mui/icons-material/Add';
 import ConfirmationNumberIcon from '@mui/icons-material/ConfirmationNumber';
 import {BusDetailsType} from '../../types';
+import {useNavigate} from 'react-router-dom';
 
 interface Passenger {
   rollNumber: string;
@@ -111,6 +112,7 @@ const AddPassengerButton = styled(Button)`
 
 const BusDetails = ({disabled}: BusDetailsType) => {
   const theme = useTheme();
+  const navigate = useNavigate();
   const [isDrawerOpen, setIsDrawerOpen] = useState(false);
   const [passengers, setPassengers] = useState<Passenger[]>([]);
   const [isAddingPassenger, setIsAddingPassenger] = useState(false);
@@ -470,6 +472,7 @@ const BusDetails = ({disabled}: BusDetailsType) => {
         >
           <Button
             variant="contained"
+            onClick={() => navigate('/demo-Page')}
             sx={{
               padding: '0.5rem 2rem',
               borderRadius: '8px',

--- a/frontend/src/components/ProtectedRoutes.tsx
+++ b/frontend/src/components/ProtectedRoutes.tsx
@@ -1,17 +1,35 @@
 import {toast} from 'react-hot-toast';
+import {useAuthStore} from '../store/authStore';
 import {Navigate} from 'react-router-dom';
+import {Box, CircularProgress} from '@mui/material';
 
 type UserProtectedRoutetypes = {
-  isAuth: boolean;
   children: React.ReactNode;
 };
 
-const UserProtectedRoute: React.FC<UserProtectedRoutetypes> = props => {
-  if (!props.isAuth) {
+const UserProtectedRoute: React.FC<UserProtectedRoutetypes> = ({children}) => {
+  const {isAuth, isloading} = useAuthStore();
+
+  if (isloading) {
+    return (
+      <Box
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+          height: '70vh',
+        }}
+      >
+        <CircularProgress size={100} />
+      </Box>
+    );
+  }
+
+  if (!isAuth) {
     toast.error('You need to login first!');
     return <Navigate to="/" replace />;
   }
-  return <>{props.children}</>;
+  return <>{children}</>;
 };
 
 export default UserProtectedRoute;

--- a/frontend/src/components/ProtectedRoutes.tsx
+++ b/frontend/src/components/ProtectedRoutes.tsx
@@ -1,0 +1,17 @@
+import {toast} from 'react-hot-toast';
+import {Navigate} from 'react-router-dom';
+
+type UserProtectedRoutetypes = {
+  isAuth: boolean;
+  children: React.ReactNode;
+};
+
+const UserProtectedRoute: React.FC<UserProtectedRoutetypes> = props => {
+  if (!props.isAuth) {
+    toast.error('You need to login first!');
+    return <Navigate to="/" replace />;
+  }
+  return <>{props.children}</>;
+};
+
+export default UserProtectedRoute;

--- a/frontend/src/components/ValidateAuth.tsx
+++ b/frontend/src/components/ValidateAuth.tsx
@@ -3,15 +3,20 @@ import {useAuthStore} from '../store/authStore';
 import axios from 'axios';
 
 const ValidateAuth: React.FC = () => {
-  const {setIsAuth, setUser} = useAuthStore();
+  const {isAuth, isloading, setIsAuth, setUser, setIsLoading} = useAuthStore();
   useEffect(() => {
     const checkAuth = async () => {
-      const res = await axios.get('http://localhost:3333/auth/me', {
-        withCredentials: true,
-      });
-      if (res.status === 200) {
-        setIsAuth(true);
-        setUser(res.data);
+      try {
+        const res = await axios.get('http://localhost:3333/auth/me', {
+          withCredentials: true,
+        });
+        if (res.status === 200) {
+          setIsAuth(true);
+          setUser(res.data);
+          setIsLoading(false);
+        }
+      } catch (error) {
+        setIsLoading(false);
       }
     };
     checkAuth();

--- a/frontend/src/pages/DemoPage/demopage.tsx
+++ b/frontend/src/pages/DemoPage/demopage.tsx
@@ -1,0 +1,9 @@
+const Demopage = () => {
+  return (
+    <div style={{textAlign: 'center'}}>
+      <h1>Demopage</h1>
+    </div>
+  );
+};
+
+export default Demopage;

--- a/frontend/src/store/authStore.tsx
+++ b/frontend/src/store/authStore.tsx
@@ -3,8 +3,10 @@ import {create} from 'zustand';
 interface AuthStore {
   isAuth: boolean;
   user: User | null;
+  isloading: boolean;
   setIsAuth: (isAuth: boolean) => void;
   setUser: (user: User | null) => void;
+  setIsLoading: (isloading: boolean) => void;
 }
 
 interface User {
@@ -17,6 +19,8 @@ interface User {
 export const useAuthStore = create<AuthStore>(set => ({
   isAuth: false,
   user: null,
+  isloading: true,
   setIsAuth: isAuth => set({isAuth}),
   setUser: user => set({user}),
+  setIsLoading: isloading => set({isloading}),
 }));


### PR DESCRIPTION
## Overview

1. This PR fixes or fixes part of #49 .
2. This PR does the following: It adds UserProtectedRoute to a demoPage(open when user clicks on 'Pay now') which redirect the user to a homePage as well as  pops a toaster if the user is not logged in otherwise opens the wrapped component .

## Essential Checklist

- [x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [x] The PR is made from a branch that's **not** called "main/master".

## Proof that changes are correct
[ProtectedRoutes.webm](https://github.com/bsoc-bitbyte/busify/assets/128511266/33e3e63e-4908-4556-a33a-ef1e80e25345)

