### PR TITLE
Fixes #82 fix(components): update styling for the resuable card components

### DIFF
--- a/frontend/src/components/TicketCard.tsx
+++ b/frontend/src/components/TicketCard.tsx
@@ -1,0 +1,179 @@
+import React from 'react';
+import {Card, CardContent, Typography, Box} from '@mui/material';
+import {styled} from '@mui/system';
+import busIcon from '../assets/busIcon.svg';
+
+const Root = styled(Card)({
+  borderRadius: '16px',
+  overflow: 'hidden',
+  backgroundColor: '#fff',
+  boxShadow: '0 4px 8px rgba(0,0,0,0.1)',
+  maxWidth: 600,
+  margin: 'auto',
+  border: '1px solid #FFC107',
+  position: 'relative',
+});
+
+const Header = styled(Box)({
+  backgroundColor: '#FFC107',
+  padding: '8px 16px',
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  borderTopLeftRadius: '16px',
+  borderTopRightRadius: '16px',
+  position: 'relative',
+  zIndex: 1,
+});
+
+const HeaderText = styled(Typography)({
+  color: '#fff',
+  fontWeight: 'bold',
+  position: 'absolute',
+  top: '-3px',
+  left: '16px',
+  backgroundColor: '#FFC107',
+  padding: '4px 8px',
+  borderRadius: '12px',
+  boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
+  zIndex: 10, // Ensuring it stays above other elements
+});
+
+const Content = styled(CardContent)({
+  padding: '16px',
+});
+
+const BusInfo = styled(Box)({
+  backgroundColor: '#FFC107',
+  padding: '8px 16px',
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  borderBottomLeftRadius: '16px',
+  borderBottomRightRadius: '16px',
+});
+
+const BusNumber = styled(Typography)({
+  fontSize: '1.75rem',
+  fontWeight: 'bold',
+  color: '#fff',
+});
+
+const TimeDate = styled(Box)({
+  textAlign: 'right',
+  color: '#fff',
+});
+
+const DashedLine = styled(Box)({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'space-between',
+  margin: '16px 0',
+});
+
+const DashedSegment = styled(Box)({
+  flex: 1,
+  borderTop: '2px dashed #FFC107',
+  position: 'relative',
+});
+
+const Circle = styled(Box)({
+  width: '12px',
+  height: '12px',
+  borderRadius: '50%',
+  backgroundColor: '#FFC107',
+});
+
+const Icon = styled('img')({
+  width: '24px',
+  height: '24px',
+});
+
+const LocationInfo = styled(Box)({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  paddingBottom: '16px',
+});
+
+const Location = styled(Box)({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+const BoldText = styled(Typography)({
+  fontWeight: 'bold',
+  WebkitTextStrokeWidth: '0.5px',
+});
+
+const BoldFooterText = styled(Typography)({
+  fontWeight: 'bold',
+  fontSize: '1.25rem',
+});
+
+interface TicketCardProps {
+  busNumber: string;
+  departure: string;
+  destination: string;
+  time: string;
+  date: string;
+  ticketId: string;
+}
+
+const TicketCard: React.FC<TicketCardProps> = ({
+  busNumber,
+  departure,
+  destination,
+  time,
+  date,
+  ticketId,
+}) => {
+  return (
+    <Root>
+      <Header>
+        <HeaderText>{ticketId}</HeaderText>
+      </Header>
+      <Content>
+        <LocationInfo>
+          <Location>
+            <BoldText variant="h6">{departure}</BoldText>
+            <BoldText variant="subtitle2" color="textSecondary">
+              PDPM IIITDM Jabalpur
+            </BoldText>
+          </Location>
+          <Location style={{textAlign: 'right'}}>
+            <BoldText variant="h6" align="right">
+              {destination}
+            </BoldText>
+            <BoldText variant="subtitle2" color="textSecondary" align="right">
+              Jabalpur City
+            </BoldText>
+          </Location>
+        </LocationInfo>
+        <DashedLine>
+          <Circle />
+          <DashedSegment />
+          <Icon src={busIcon} alt="Bus Icon" />
+          <DashedSegment />
+          <Circle />
+        </DashedLine>
+      </Content>
+      <BusInfo>
+        <Box>
+          <BoldFooterText variant="subtitle2" style={{color: '#fff'}}>
+            Bus No.
+          </BoldFooterText>
+          <BusNumber className={`${BusNumber} ${BoldFooterText}`}>
+            {busNumber}
+          </BusNumber>
+        </Box>
+        <TimeDate>
+          <BoldFooterText variant="subtitle2">{date}</BoldFooterText>
+          <BoldFooterText variant="h6">{time}</BoldFooterText>
+        </TimeDate>
+      </BusInfo>
+    </Root>
+  );
+};
+
+export default TicketCard;

--- a/frontend/src/components/TicketCardClose.tsx
+++ b/frontend/src/components/TicketCardClose.tsx
@@ -1,0 +1,217 @@
+import React from 'react';
+import {Card, CardContent, Typography, Box} from '@mui/material';
+import {styled} from '@mui/system';
+
+const Root = styled(Card)({
+  borderRadius: '16px',
+  overflow: 'hidden',
+  backgroundColor: '#FFC107',
+  maxWidth: 600,
+  margin: 'auto',
+  padding: '16px',
+  boxShadow: '0 4px 16px rgba(0,0,0,0.2)',
+  position: 'relative',
+  color: '#fff',
+});
+
+const Header = styled(Box)({
+  backgroundColor: '#FFC107',
+  padding: '8px 16px',
+  display: 'flex',
+  justifyContent: 'flex-start',
+  alignItems: 'center',
+  borderTopLeftRadius: '16px',
+  borderTopRightRadius: '16px',
+  color: '#fff',
+  fontWeight: 'bold',
+  position: 'relative',
+  zIndex: 1,
+});
+
+const HeaderText = styled(Typography)({
+  color: '#fff',
+  fontWeight: 'bold',
+  position: 'absolute',
+  top: '-10px',
+  left: '16px',
+  backgroundColor: '#FFC107',
+  padding: '4px 8px',
+  borderRadius: '12px',
+  boxShadow: '0 2px 4px rgba(0,0,0,0.2)',
+  zIndex: 10,
+});
+
+const Content = styled(CardContent)({
+  paddingTop: '16px',
+  backgroundColor: '#FFC107',
+  color: '#fff',
+});
+
+const BusInfo = styled(Box)({
+  padding: '8px 16px',
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  borderBottomLeftRadius: '16px',
+  borderBottomRightRadius: '16px',
+  backgroundColor: '#FFC107',
+});
+
+const BusNumber = styled(Typography)({
+  fontSize: '1.75rem',
+  fontWeight: 'bold',
+  color: '#fff',
+});
+
+const TimeDate = styled(Box)({
+  textAlign: 'right',
+  color: '#fff',
+});
+
+const DashedLine = styled(Box)({
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  margin: '16px 0',
+});
+
+const DashedSegment = styled(Box)({
+  flex: 1,
+  borderTop: '2px dashed #fff',
+  position: 'relative',
+  margin: '0 8px',
+});
+
+const Circle = styled(Box)({
+  width: '16px',
+  height: '16px',
+  borderRadius: '50%',
+  border: '2px solid #fff',
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+});
+
+const InnerCircle = styled(Box)({
+  width: '8px',
+  height: '8px',
+  borderRadius: '50%',
+  backgroundColor: '#fff',
+});
+
+const LocationInfo = styled(Box)({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'center',
+  paddingBottom: '16px',
+});
+
+const Location = styled(Box)({
+  display: 'flex',
+  flexDirection: 'column',
+});
+
+const DoneStamp = styled(Box)({
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%) rotate(-20deg)',
+  color: '#fff',
+  fontSize: '2rem',
+  fontWeight: 'bold',
+  opacity: 0.1,
+  textTransform: 'uppercase',
+  textAlign: 'center',
+  zIndex: 10,
+});
+
+const FadedCircle = styled(Box)({
+  position: 'absolute',
+  top: '50%',
+  left: '50%',
+  transform: 'translate(-50%, -50%)',
+  width: '200px',
+  height: '200px',
+  borderRadius: '50%',
+  border: '4px dashed #fff',
+  opacity: 0.1,
+  zIndex: 9,
+});
+
+const BoldText = styled(Typography)({
+  fontWeight: 'bold',
+});
+
+const BoldFooterText = styled(Typography)({
+  fontWeight: 'bold',
+  fontSize: '1.25rem',
+});
+
+interface TicketCardCloseProps {
+  busNumber: string;
+  departure: string;
+  destination: string;
+  time: string;
+  date: string;
+  ticketId: string;
+}
+
+const TicketCardClose: React.FC<TicketCardCloseProps> = ({
+  busNumber,
+  departure,
+  destination,
+  time,
+  date,
+  ticketId,
+}) => {
+  return (
+    <Root>
+      <Header>
+        <HeaderText>{ticketId}</HeaderText>
+      </Header>
+      <FadedCircle />
+      <DoneStamp>DONE</DoneStamp>
+      <Content>
+        <LocationInfo>
+          <Location>
+            <BoldText variant="h6">{departure}</BoldText>
+            <BoldText variant="subtitle2">PDPM IIITDM Jabalpur</BoldText>
+          </Location>
+          <Location style={{textAlign: 'right'}}>
+            <BoldText variant="h6" align="right">
+              {destination}
+            </BoldText>
+            <BoldText variant="subtitle2" align="right">
+              Jabalpur City
+            </BoldText>
+          </Location>
+        </LocationInfo>
+        <DashedLine>
+          <Circle>
+            <InnerCircle />
+          </Circle>
+          <DashedSegment />
+          <Circle>
+            <InnerCircle />
+          </Circle>
+        </DashedLine>
+      </Content>
+      <BusInfo>
+        <Box>
+          <BoldFooterText variant="subtitle2" style={{color: '#fff'}}>
+            Bus No.
+          </BoldFooterText>
+          <BusNumber className={`${BusNumber} ${BoldFooterText}`}>
+            {busNumber}
+          </BusNumber>
+        </Box>
+        <TimeDate>
+          <BoldFooterText variant="subtitle2">{date}</BoldFooterText>
+          <BoldFooterText variant="h6">{time}</BoldFooterText>
+        </TimeDate>
+      </BusInfo>
+    </Root>
+  );
+};
+
+export default TicketCardClose;


### PR DESCRIPTION
## Overview
<!--
READ ME FIRST:
Please answer *both* questions below and check off every point from the Essential Checklist!
If there is no corresponding issue number, fill in N/A where it says [fill_in_number_here] below in 1.
-->

1. This PR fixes or fixes part of #82 .
2. This PR does the following: This PR contains reusable card components for the upcoming and completed bus cards in the components folder of the src folder of the frontend folder of the project.

## Essential Checklist

- [ x] The PR title starts with "Fix #bugnum: ", followed by a short, clear summary of the changes. (If this PR fixes part of an issue, prefix the title with "Fix part of #bugnum: ...".)
- [ x] "Allow edits from maintainers" is checked. (See [here](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for instructions on how to enable it.)
- [ x] The PR is made from a branch that's **not** called "main/master".

## Proof that changes are correct
<img width="627" alt="Screenshot 2024-06-05 at 2 44 45 AM" src="https://github.com/bsoc-bitbyte/busify/assets/136831315/910fbec7-e348-4c2e-bc39-ed54a4153d51">

<img width="890" alt="Screenshot 2024-06-05 at 3 11 42 AM" src="https://github.com/bsoc-bitbyte/busify/assets/136831315/f07a2124-e78a-4a91-a01c-cf7cb70d932c">

This is the first reusable card component showing that it is responsive across all devices. this is the upcoming component.

<img width="622" alt="Screenshot 2024-06-05 at 2 49 56 AM" src="https://github.com/bsoc-bitbyte/busify/assets/136831315/0ff647ef-e3cb-4985-9eda-692cabd6150e">

<img width="1180" alt="Screenshot 2024-06-05 at 3 12 38 AM" src="https://github.com/bsoc-bitbyte/busify/assets/136831315/06eb3fce-6578-4bdb-906d-bc5d9de59595">

This is the second reusable card component that is being used here. this is the completed component.


The data in these cards are not hardcoded and are rendered creating a new route path in the App.jsx file giving appropriate demo data there to display the card components successfully.
The components are ready to be rendered anywhere in the project efficiently from the components folder.

Thank You



## PR Pointers

- If you need a review or an answer to a question, and don't have permissions to assign people, **leave a comment** like the following: "{{Question/comment}} @{{reviewer_username}} PTAL".
- Never force push. If you do, your PR will be closed.
